### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/NoBug.ino/keywords.txt
+++ b/NoBug.ino/keywords.txt
@@ -6,11 +6,11 @@
 # Class (KEYWORD1)
 #######################################
 
-NoSerial KEYWORD1
+NoSerial	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-autoPrint KEYWORD2
-commonPrint KEYWORD2
+autoPrint	KEYWORD2
+commonPrint	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords